### PR TITLE
Make GPS primary for sharp turns and limit vision to lane-centering assist

### DIFF
--- a/NavQPlus/ros2_ws/rover_project/launch/rover_launch.py
+++ b/NavQPlus/ros2_ws/rover_project/launch/rover_launch.py
@@ -98,7 +98,9 @@ def generate_launch_description():
             parameters=[{
                 'waypoint_reached_m': 3.0,
                 'heading_tolerance_deg': 60.0,
+                'sharp_turn_deg': 40.0,
                 'heading_hysteresis_deg': 10.0,
+                'vision_assist_max_heading_err_deg': 35.0,
                 'command_rate_hz': 5.0,
                 'gps_timeout_s': 5.0,
                 'min_fix_type': 2,

--- a/NavQPlus/ros2_ws/rover_project/scripts/waypoint_follower_node.py
+++ b/NavQPlus/ros2_ws/rover_project/scripts/waypoint_follower_node.py
@@ -45,6 +45,7 @@ class WaypointFollowerNode(Node):
         self.declare_parameter('waypoint_reached_m', 2.5)
         self.declare_parameter('heading_tolerance_deg', 60.0)       # Heading Tolerance
         self.declare_parameter('sharp_turn_deg', 45.0)
+        self.declare_parameter('vision_assist_max_heading_err_deg', 35.0)
         self.declare_parameter('command_rate_hz', 5.0)
         self.declare_parameter('gps_timeout_s', 5.0)
         self.declare_parameter('min_fix_type', 2)
@@ -59,7 +60,9 @@ class WaypointFollowerNode(Node):
 
         self.wp_threshold = self.get_parameter('waypoint_reached_m').value
         self.heading_tol = self.get_parameter('heading_tolerance_deg').value
+        self.sharp_turn_deg = self.get_parameter('sharp_turn_deg').value
         self.heading_hysteresis = self.get_parameter('heading_hysteresis_deg').value
+        self.vision_assist_max_heading_err = self.get_parameter('vision_assist_max_heading_err_deg').value
         self.gps_timeout = self.get_parameter('gps_timeout_s').value
         self.min_fix_type = self.get_parameter('min_fix_type').value
         self.obstacle_stop_mm = self.get_parameter('obstacle_stop_mm').value
@@ -233,37 +236,54 @@ class WaypointFollowerNode(Node):
         err = self.angle_diff(self.current_heading, bearing)
         abs_err = abs(err)
 
+        gps_turn_is_sharp = abs_err >= self.sharp_turn_deg
+
         if abs_err <= self.heading_tol:
             cmd = CMD_FORWARD_STRAIGHT
+            command_source = 'gps-straight'
+        elif gps_turn_is_sharp:
+            # Long-range waypoint tracking takes priority on large heading errors.
+            cmd = CMD_FORWARD_RIGHT if err > 0 else CMD_FORWARD_LEFT
+            command_source = 'gps-sharp-turn'
         elif self.last_cmd == CMD_FORWARD_LEFT:
             # Already curving left — only switch right if error is well past centre
             cmd = CMD_FORWARD_RIGHT if err > self.heading_tol + self.heading_hysteresis else CMD_FORWARD_LEFT
+            command_source = 'gps-hysteresis'
         elif self.last_cmd == CMD_FORWARD_RIGHT:
             # Already curving right — only switch left if error is well past centre
             cmd = CMD_FORWARD_LEFT if err < -(self.heading_tol + self.heading_hysteresis) else CMD_FORWARD_RIGHT
+            command_source = 'gps-hysteresis'
         else:
             cmd = CMD_FORWARD_RIGHT if err > 0 else CMD_FORWARD_LEFT
+            command_source = 'gps-heading'
 
         vision_recent = (time.time() - self.last_vision_time) < self.vision_timeout_s
         vision_status = 'stale'
         if vision_recent and self.vision_error != 9999.0:
             v_err = self.vision_error
             vision_status = f"{v_err:.0f}px"
-            # Positive vision error means path center is to the right of image center.
-            if v_err > self.vision_error_strong_px:
-                cmd = CMD_FORWARD_RIGHT
-            elif v_err < -self.vision_error_strong_px:
-                cmd = CMD_FORWARD_LEFT
-            elif abs(v_err) > self.vision_error_deadband_px:
-                if cmd == CMD_FORWARD_STRAIGHT:
+            # Positive vision error means path center is right of image center.
+            # Vision is lane-centering assist only; GPS remains primary for sharp turns.
+            vision_allowed = (not gps_turn_is_sharp) and (abs_err <= self.vision_assist_max_heading_err)
+            if vision_allowed:
+                if v_err > self.vision_error_strong_px:
+                    cmd = CMD_FORWARD_RIGHT
+                    command_source = 'vision-strong'
+                elif v_err < -self.vision_error_strong_px:
+                    cmd = CMD_FORWARD_LEFT
+                    command_source = 'vision-strong'
+                elif abs(v_err) > self.vision_error_deadband_px and cmd == CMD_FORWARD_STRAIGHT:
                     cmd = CMD_FORWARD_RIGHT if v_err > 0 else CMD_FORWARD_LEFT
+                    command_source = 'vision-assist'
+            else:
+                vision_status = f"{v_err:.0f}px (gps-priority)"
 
         self.send_cmd(cmd)
 
         self.get_logger().info(
             f"  WP{self.current_wp_index}: {dist:.1f}m | "
             f"bearing={bearing:.0f}° heading={self.current_heading:.0f}° "
-            f"err={err:.0f}° vision={vision_status} → cmd={cmd} | "
+            f"err={err:.0f}° vision={vision_status} src={command_source} → cmd={cmd} | "
             f"GPS: {self.current_num_sats}sats HDOP={self.current_hdop:.1f} h_acc={self.current_h_acc:.1f}m")
 
     #  HELPERS


### PR DESCRIPTION
### Motivation
- Improve coordination between sensors so ultrasonic/cliff safety still preempts navigation while GPS guides long-range turns and vision provides only lane-centering corrections.
- Reduce unwanted vision overrides during large heading corrections so the rover follows waypoint geometry for sharp turns while keeping smoother, vision-based centering when appropriate.

### Description
- Added parameter `vision_assist_max_heading_err_deg` and wired into `rover_launch.py` to allow tuning when vision may influence steering.
- Introduced `sharp_turn_deg` usage in `waypoint_follower_node.py` so GPS-based commands take priority when heading error exceeds the sharp-turn threshold.
- Gate vision corrections behind heading-error checks so vision only adjusts steering when `gps_turn_is_sharp` is false and heading error is within `vision_assist_max_heading_err`.
- Added `src=...` telemetry in the waypoint follower log lines to indicate whether the final command came from GPS logic or vision assist for easier tuning and debugging.
- Changes made in `NavQPlus/ros2_ws/rover_project/scripts/waypoint_follower_node.py` and launch defaults in `NavQPlus/ros2_ws/rover_project/launch/rover_launch.py`.

### Testing
- Ran `python -m py_compile NavQPlus/ros2_ws/rover_project/scripts/waypoint_follower_node.py NavQPlus/ros2_ws/rover_project/launch/rover_launch.py` and the files compiled successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a0e46f5128832abddcb4b47ead88d8)